### PR TITLE
updated Serving static resources section

### DIFF
--- a/docs/vertx-web/java/index.html
+++ b/docs/vertx-web/java/index.html
@@ -2347,10 +2347,10 @@ or from the classpath. The default static file directory is <code>webroot</code>
 </div>
 <div class="paragraph">
 <p>For example, if there was a request with path <code>/static/css/mystyles.css</code> the static serve will look for a file in the
-directory <code>webroot/static/css/mystyle.css</code>.</p>
+directory <code>webroot/css/mystyle.css</code>.</p>
 </div>
 <div class="paragraph">
-<p>It will also look for a file on the classpath called <code>webroot/static/css/mystyle.css</code>. This means you can package up all your
+<p>It will also look for a file on the classpath called <code>webroot/css/mystyle.css</code>. This means you can package up all your
 static resources into a jar file (or fatjar) and distribute them like that.</p>
 </div>
 <div class="paragraph">


### PR DESCRIPTION
The documentation of `Serving static resources` is misleading, If the static handler is configured as `router.route("/static/*").handler(StaticHandler.create())` it will serve the static content from `webroot` directory, instead of `webroot/static` as stated in the docs.

please refer to the ![screenshot](https://cloud.githubusercontent.com/assets/5792205/25609978/014537d4-2f54-11e7-97fc-c378c50f4d88.png)

related issue on `vertx-web`  [here](https://github.com/vert-x3/vertx-web/issues/419)

and the actual code which remove the `prefix` for static resources [here](https://github.com/vert-x3/vertx-web/blob/master/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java#L361)
